### PR TITLE
Fix unused constant

### DIFF
--- a/glass.cpp
+++ b/glass.cpp
@@ -34,7 +34,6 @@
 
 static UINT ENABLE = 1;
 static constexpr UINT AUTO = 0; // DWMSBT_AUTO
-static constexpr UINT NONE = 1; // DWMSBT_NONE
 static constexpr UINT MAINWINDOW = 2; // DWMSBT_MAINWINDOW
 static constexpr UINT TRANSIENTWINDOW = 3; // DWMSBT_TRANSIENTWINDOW
 static constexpr UINT TABBEDWINDOW = 4; // DWMSBT_TABBEDWINDOW


### PR DESCRIPTION
## Summary
- remove unused `NONE` constant in `glass.cpp`

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -c glass.cpp -o glass.o` *(fails: fatal error: windhawk_utils.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68722bed77b483259a129bc2a29a84a6